### PR TITLE
Avoind using lookup() in documentation

### DIFF
--- a/cloud/openstack/os_keypair.py
+++ b/cloud/openstack/os_keypair.py
@@ -63,7 +63,7 @@ EXAMPLES = '''
       cloud: mordred
       state: present
       name: ansible_key
-      public_key: "{{ lookup('file','~/.ssh/id_rsa.pub') }}"
+      public_key_file: ~/.ssh/id_rsa.pub
 
 # Creates a new key pair and the private key returned after the run.
 - os_keypair:


### PR DESCRIPTION
lookup() is currently broken (current Ansible devel branch), so better to avoid
it in our examples.
