### PR TITLE
Update to os security group Module

### DIFF
--- a/cloud/openstack/os_security_group.py
+++ b/cloud/openstack/os_security_group.py
@@ -28,6 +28,7 @@ DOCUMENTATION = '''
 module: os_security_group
 short_description: Add/Delete security groups from an OpenStack cloud.
 extends_documentation_fragment: openstack
+author: "Monty Taylor (@emonty)"
 version_added: "2.0"
 description:
    - Add or Remove security groups from an OpenStack cloud.

--- a/cloud/openstack/os_security_group.py
+++ b/cloud/openstack/os_security_group.py
@@ -28,7 +28,6 @@ DOCUMENTATION = '''
 module: os_security_group
 short_description: Add/Delete security groups from an OpenStack cloud.
 extends_documentation_fragment: openstack
-author: "Monty Taylor (@emonty)"
 version_added: "2.0"
 description:
    - Add or Remove security groups from an OpenStack cloud.
@@ -48,6 +47,8 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+
+requirements: ["shade"]
 '''
 
 EXAMPLES = '''
@@ -114,24 +115,24 @@ def main():
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, secgroup))
 
-        changed = False
         if state == 'present':
             if not secgroup:
                 secgroup = cloud.create_security_group(name, description)
-                changed = True
+                module.exit_json(changed=True, id=secgroup['id'])
             else:
                 if _needs_update(module, secgroup):
                     secgroup = cloud.update_security_group(
                         secgroup['id'], description=description)
-                    changed = True
-            module.exit_json(
-                changed=changed, id=secgroup.id, secgroup=secgroup)
+                    module.exit_json(changed=True, id=secgroup['id'])
+                else:
+                    module.exit_json(changed=False, id=secgroup['id'])
 
         if state == 'absent':
-            if secgroup:
+            if not secgroup:
+                module.exit_json(changed=False)
+            else:
                 cloud.delete_security_group(secgroup['id'])
-                changed=True
-            module.exit_json(changed=changed)
+                module.exit_json(changed=True)
 
     except shade.OpenStackCloudException as e:
         module.fail_json(msg=e.message)


### PR DESCRIPTION
I have been using this module while creating a new Ansible playbook and ran into some small issues, specifically secgroup['id'] not being returned.  This is required when creating security group rules, since we have to refer to the respective security group by id.
